### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,8 @@
-## Maintainers
+## Overview
+
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
 
 | Maintainer       | GitHub ID                                           | Affiliation |
 | ---------------- | --------------------------------------------------- | ----------- |
@@ -7,4 +11,4 @@
 | Sayali Gaikawad  | [gaiksaya](https://github.com/gaiksaya)             | Amazon      |
 | Rishab Singh     | [rishabh6788](https://github.com/rishabh6788)       | Amazon      |
 | Zelin Hao        | [zelinh](https://github.com/zelinh)                 | Amazon      |
-| Prudhvi Godithi  | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon       | 
+| Prudhvi Godithi  | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon      |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.