### PR TITLE
fix: replace deprecated org.label-schema container labels

### DIFF
--- a/2.x/Dockerfile
+++ b/2.x/Dockerfile
@@ -98,13 +98,12 @@ RUN ./opensearch-onetime-setup.sh
 EXPOSE 9200 9300 9600 9650
 
 # Label
-LABEL org.label-schema.schema-version="1.0" \
-  org.label-schema.name="opensearch" \
-  org.label-schema.version="$OS_VERSION" \
-  org.label-schema.url="https://opensearch.org" \
-  org.label-schema.vcs-url="https://github.com/OpenSearch" \
-  org.label-schema.license="Apache-2.0" \
-  org.label-schema.vendor="OpenSearch"
+LABEL org.opencontainers.image.title="opensearch" \
+  org.opencontainers.image.version="$OS_VERSION" \
+  org.opencontainers.image.url="https://opensearch.org" \
+  org.opencontainers.image.source="https://github.com/opensearch-project/docker-images" \
+  org.opencontainers.image.licenses="Apache-2.0" \
+  org.opencontainers.image.vendor="OpenSearch"
 
 # CMD to run
  ENTRYPOINT ["./opensearch-docker-entrypoint.sh"]


### PR DESCRIPTION
### Description

This PR replaces the [deprecated](https://github.com/label-schema/label-schema.org) `org.label-schema` labels with the `org.opencontainers.image` ([ref](https://github.com/opencontainers/image-spec/blob/main/annotations.md#back-compatibility-with-label-schema)) labels. The PR also corrects the broken repository URL `https://github.com/OpenSearch` set in the labels that leads to a private user profile instead of the OpenSearch container repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
