### PR TITLE
Fix PA log path

### DIFF
--- a/2.x/bin/opensearch-docker-entrypoint.sh
+++ b/2.x/bin/opensearch-docker-entrypoint.sh
@@ -58,7 +58,7 @@ function setupPerformanceAnalyzerPlugin {
             echo "Disabling execution of $OPENSEARCH_HOME/bin/$PERFORMANCE_ANALYZER_PLUGIN/performance-analyzer-agent-cli for OpenSearch Performance Analyzer Plugin"
         else
             echo "Enabling execution of OPENSEARCH_HOME/bin/$PERFORMANCE_ANALYZER_PLUGIN/performance-analyzer-agent-cli for OpenSearch Performance Analyzer Plugin"
-            $OPENSEARCH_HOME/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli > $OPENSEARCH_HOME/logs/performance-analyzer.log 2>&1 &
+            $OPENSEARCH_HOME/bin/opensearch-performance-analyzer/performance-analyzer-agent-cli > /tmp/PerformanceAnalyzer.log 2>&1 &
         fi
     else
         echo "OpenSearch Performance Analyzer Plugin does not exist, disable by default"


### PR DESCRIPTION
Signed-off-by: David Zane <davizane@amazon.com>

### Description
Users are reporting large file sizes at `/usr/share/opensearch/logs/performance-analyzer.log` due to the log not rotating properly.

### Fix
Update PA log filepath in opensearch-build from `$OPENSEARCH_HOME/logs/performance-analyzer.log` to `/tmp/PerformanceAnalyzer.log` to allow for rotation by PA-RCA (https://github.com/opensearch-project/performance-analyzer-rca/blob/main/config/log4j2.xml#L7).

### Issues Resolved
Fixes https://github.com/opensearch-project/performance-analyzer/issues/226

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
