### PR TITLE
Added ability to run as any UID/on OpenShift

### DIFF
--- a/2.x/Dockerfile
+++ b/2.x/Dockerfile
@@ -7,7 +7,7 @@
 # Build arguments:
 #   VERSION: Required. Used to label the image.
 #   UID: Optional. Specify the opensearch userid. Defaults to 1000.
-#   GID: Optional. Specify the opensearch groupid. Defaults to 1000.
+#   GID: Optional. Specify the opensearch groupid. Defaults to 0.
 #   OPENSEARCH_HOME: Optional. Specify the opensearch root directory. Defaults to /usr/share/opensearch.
 
 
@@ -15,7 +15,7 @@
 FROM amazonlinux:2 AS linux_stage_0
 
 ARG UID=1000
-ARG GID=1000
+ARG GID=0
 ARG TEMP_DIR=/tmp/opensearch
 ARG OPENSEARCH_HOME=/usr/share/opensearch
 ARG OPENSEARCH_PATH_CONF=$OPENSEARCH_HOME/config
@@ -28,7 +28,7 @@ ARG OS_VERSION=2.5.0
 RUN yum update -y && yum install -y tar gzip shadow-utils which && yum clean all
 
 # Create an opensearch user, group, and directory
-RUN groupadd -g $GID opensearch && \
+RUN if [[ ! "$GID" -eq "0" ]]; then groupadd -g $GID opensearch; fi && \
     adduser -u $UID -g $GID -d $OPENSEARCH_HOME opensearch && \
     mkdir $TEMP_DIR
 
@@ -53,27 +53,28 @@ RUN tar --warning=no-timestamp -zxf $TEMP_DIR/opensearch.tar.gz -C $OPENSEARCH_H
     if [[ -d $SECURITY_PLUGIN_DIR ]] ; then chmod -v 750 $SECURITY_PLUGIN_DIR/tools/* ; fi && \
     rm -rf $TEMP_DIR
 
-COPY config/* $OPENSEARCH_PATH_CONF/
-COPY bin/* $OPENSEARCH_HOME/
+COPY --chown=$UID:$GID config/* $OPENSEARCH_PATH_CONF/
+COPY --chown=$UID:$GID bin/* $OPENSEARCH_HOME/
 RUN if [[ -d $PERFORMANCE_ANALYZER_PLUGIN_CONFIG_DIR ]] ; then mv $OPENSEARCH_PATH_CONF/performance-analyzer.properties $PERFORMANCE_ANALYZER_PLUGIN_CONFIG_DIR/ ; fi
 ########################### Stage 1 ########################
 # Copy working directory to the actual release docker images
 FROM amazonlinux:2
 
 ARG UID=1000
-ARG GID=1000
+ARG GID=0
 ARG OPENSEARCH_HOME=/usr/share/opensearch
 ARG OS_VERSION=2.5.0
 
 RUN yum update -y && yum install -y tar gzip shadow-utils which && yum clean all
 
 # Create an opensearch user, group
-RUN groupadd -g $GID opensearch && \
+RUN if [[ ! "$GID" -eq "0" ]]; then groupadd -g $GID opensearch; fi && \
     adduser -u $UID -g $GID -d $OPENSEARCH_HOME opensearch
 
 # Copy from Stage0
 COPY --from=linux_stage_0 --chown=$UID:$GID $OPENSEARCH_HOME $OPENSEARCH_HOME
 WORKDIR $OPENSEARCH_HOME
+RUN chmod -R g=u $OPENSEARCH_HOME
 
 # Set $JAVA_HOME
 RUN echo "export JAVA_HOME=$OPENSEARCH_HOME/jdk" >> /etc/profile.d/java_home.sh && \


### PR DESCRIPTION
Signed-off-by: Django Cass <django@dcas.dev>

### Description

This change updates the `Dockerfile` to modify group and file permissions so that the resulting OpenSearch container can be run as a non-standard Linux user ID. For example, running on OpenShift would require using the `anyuid` SCC as OpenSearch would throw `permission denied` errors when not running as `1000:1000`.

Behaviour can be confirmed by running:

```shell
docker run opensearch # would work
docker run --user=12345:0 opensearch # would fail with permission denied error but now works
```

As the default user ID is still `1000`, this shouldn't cause any backwards compatibility issues. 

The `if [[ ! "$GID" -eq "0" ]];...` check was added to ensure that the `Dockerfile` behaviour is identical to what it used to be if the `GID` arg is set to a non-zero value.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
