### PR TITLE
Remove elasticsearch workdir

### DIFF
--- a/2.x/Dockerfile
+++ b/2.x/Dockerfile
@@ -32,9 +32,6 @@ RUN groupadd -g $GID opensearch && \
     adduser -u $UID -g $GID -d $OPENSEARCH_HOME opensearch && \
     mkdir $TEMP_DIR
 
-RUN mkdir /usr/share/elasticsearch
-WORKDIR /usr/share/elasticsearch
-
 RUN set -eux ; \
     cur_arch="" ; \
     case "$(arch)" in \


### PR DESCRIPTION
### Description

removed the command line that makes es work dir
because it seems that there is no need to create elasticsearch work dir

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
