### PR TITLE
fix vcs label

### DIFF
--- a/2.x/Dockerfile
+++ b/2.x/Dockerfile
@@ -102,7 +102,7 @@ LABEL org.label-schema.schema-version="1.0" \
   org.label-schema.name="opensearch" \
   org.label-schema.version="$OS_VERSION" \
   org.label-schema.url="https://opensearch.org" \
-  org.label-schema.vcs-url="https://github.com/OpenSearch" \
+  org.label-schema.vcs-url="https://github.com/opensearch-project/OpenSearch" \
   org.label-schema.license="Apache-2.0" \
   org.label-schema.vendor="OpenSearch"
 


### PR DESCRIPTION
### Description
The label points to wrong organization.
It now points to the openserach repo, so tools like renovate can show changelogs on PR's

### Issues Resolved
none

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
