### PR TITLE
Set UID and GID of opensearch user and group to 10000

### DIFF
--- a/2.x/Dockerfile
+++ b/2.x/Dockerfile
@@ -6,16 +6,16 @@
 # It assumes that the working directory contains these files: an OpenSearch tarball (opensearch.tgz), log4j2.properties, opensearch.yml, opensearch-docker-entrypoint.sh, opensearch-onetime-setup.sh.
 # Build arguments:
 #   VERSION: Required. Used to label the image.
-#   UID: Optional. Specify the opensearch userid. Defaults to 1000.
-#   GID: Optional. Specify the opensearch groupid. Defaults to 1000.
+#   UID: Optional. Specify the opensearch userid. Defaults to 10000.
+#   GID: Optional. Specify the opensearch groupid. Defaults to 10000.
 #   OPENSEARCH_HOME: Optional. Specify the opensearch root directory. Defaults to /usr/share/opensearch.
 
 
 ########################### Stage 0 ########################
 FROM amazonlinux:2 AS linux_stage_0
 
-ARG UID=1000
-ARG GID=1000
+ARG UID=10000
+ARG GID=10000
 ARG TEMP_DIR=/tmp/opensearch
 ARG OPENSEARCH_HOME=/usr/share/opensearch
 ARG OPENSEARCH_PATH_CONF=$OPENSEARCH_HOME/config
@@ -60,8 +60,8 @@ RUN if [[ -d $PERFORMANCE_ANALYZER_PLUGIN_CONFIG_DIR ]] ; then mv $OPENSEARCH_PA
 # Copy working directory to the actual release docker images
 FROM amazonlinux:2
 
-ARG UID=1000
-ARG GID=1000
+ARG UID=10000
+ARG GID=10000
 ARG OPENSEARCH_HOME=/usr/share/opensearch
 ARG OS_VERSION=2.5.0
 


### PR DESCRIPTION
### Description
Change the UID and GID of the opensearch user and group to 10000

### Issues Resolved
Closes https://github.com/opensearch-project/docker-images/issues/33

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
